### PR TITLE
Closing socket connection before usage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -22,6 +22,49 @@ The subscriber will make sure that a message will be sent to Logstash if:
 * ``message.level >= 'MIN_LOG_LEVEL_LOGSTASH' || 'MIN_LOG_LEVEL'``
 * ``process.env.LOGSTASH_LOGGING !== 'true' || settings.LOGSTASH_LOGGING !== true``
 
+
+## Usage within child_process.fork()
+Since within child_process we need to pipe socket's tcp channel, the best way to manage logging is to transfer them via ipc channel:
+
+```js
+const cp = require('child_process');
+const { stream } = require('logtify')();
+
+// creating a forked process
+const process = cp.fork('<path>/some.js', [], {
+  env: { FORKED: true }
+});
+
+process.on('message', data => {
+  // passing message from child to logger
+  stream.log(data.level, data.message, ...data.meta)
+});
+
+```
+
+```js
+// some.js
+
+const { logger, stream } = require('logtify')();
+
+// if from forked process
+if (process.env.FORKED) {
+  stream.log = (level, message, ...meta) => {
+    // if ipc channel was not closed
+    if (process.channel) {
+      process.send({
+        level,
+        message,
+        meta: meta || []
+      });
+    }
+  };
+}
+
+
+logger.info('Hello world', { from: 'forked_process' });
+```
+
 **Settings**:
 Module can be configured by both env variables or config object. However, env variables have a higher priority.
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -35,9 +35,18 @@ class Logstash extends stream.Subscriber {
         port: parseInt(this.settings.LOGSTASH_PORT, 10),
         host: this.settings.LOGSTASH_HOST
       });
+      this.winston.transports.logstash.close();
     } else {
       console.warn('Logstash logging was not initialized due to missing LOGSTASH_HOST or LOGSTASH_PORT');
     }
+
+    this.cleanup = this.cleanup.bind(this);
+
+    process.once('exit', this.cleanup);
+    process.once('SIGINT', this.cleanup);
+    process.once('SIGTERM', this.cleanup);
+    process.once('uncaughtException', this.cleanup);
+
     this.name = 'LOGSTASH';
   }
 
@@ -77,6 +86,9 @@ class Logstash extends stream.Subscriber {
   **/
   handle(message) {
     if (this.isReady() && this.isEnabled() && message) {
+      if (!this.winston.transports.logstash.connected) {
+        this.winston.transports.logstash.connect();
+      }
       const content = message.payload;
       const messageLevel = this.logLevels.has(content.level) ? content.level : this.logLevels.get('default');
       const minLogLevel = this.getMinLogLevel(this.settings, this.name);
@@ -95,6 +107,14 @@ class Logstash extends stream.Subscriber {
         const metadata = jsonify ? message.stringifyMetadata() : content.meta;
         this.winston.log(messageLevel, messageText, metadata);
       }
+    } else if (this.isReady() && this.winston.transports.logstash.connected) {
+      this.winston.transports.logstash.close();
+    }
+  }
+
+  cleanup() {
+    if (this.isReady()) {
+      this.winston.transports.logstash.close();
     }
   }
 }

--- a/test/logstash-spec.js
+++ b/test/logstash-spec.js
@@ -1,7 +1,11 @@
 const assert = require('assert');
 const sinon = require('sinon');
 const Logstash = require('../src/index');
+require('logtify')({});
+require('logtify')({});
+require('logtify')({});
 const { stream } = require('logtify')();
+
 
 const { Message } = stream;
 


### PR DESCRIPTION
By default, we close socket connection and open it only when it will be used.
Also added a graceful shutdown to make sure we don't have idling tcp connection.

This unblocks it's work in child_process if not enabled.